### PR TITLE
Switch on travis's caching features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,11 @@ matrix:
       env: TARGET=x86_64-apple-darwin
            MACOSX_DEPLOYMENT_TARGET=10.7
 
+cache:
+  - cargo
+  - directories:
+    - target/$TARGET/openssl/openssl-install
+
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,89 +17,89 @@ matrix:
     # Cross builds happen in the `rust-slave-linux-cross` image to ensure that
     # we use the right cross compilers for these targets. That image should
     # bundle all the gcc cross compilers to enable us to build OpenSSL
-    # - os: linux
-    #   env: TARGET=arm-unknown-linux-gnueabi
-    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-    #        SKIP_TESTS=1
-    # - os: linux
-    #   env: TARGET=arm-unknown-linux-gnueabihf
-    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-    #        SKIP_TESTS=1
-    # - os: linux
-    #   env: TARGET=armv7-unknown-linux-gnueabihf
-    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-    #        SKIP_TESTS=1
-    # - os: linux
-    #   env: TARGET=aarch64-unknown-linux-gnu
-    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-    #        SKIP_TESTS=1
-    # - os: linux
-    #   env: TARGET=x86_64-unknown-freebsd
-    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-    #        SKIP_TESTS=1
-    # - os: linux
-    #   env: TARGET=x86_64-unknown-netbsd
-    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-    #        SKIP_TESTS=1
-    # - os: linux
-    #   env: TARGET=powerpc-unknown-linux-gnu
-    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-    #        SKIP_TESTS=1
-    # - os: linux
-    #   env: TARGET=powerpc64-unknown-linux-gnu
-    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-    #        SKIP_TESTS=1
-    # - os: linux
-    #   env: TARGET=powerpc64le-unknown-linux-gnu
-    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-    #        SKIP_TESTS=1
-    # - os: linux
-    #   env: TARGET=mips-unknown-linux-gnu
-    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-    #        SKIP_TESTS=1
-    # - os: linux
-    #   env: TARGET=mipsel-unknown-linux-gnu
-    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-    #        SKIP_TESTS=1
-    # - os: linux
-    #   env: TARGET=mips64-unknown-linux-gnuabi64
-    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-    #        SKIP_TESTS=1
-    # - os: linux
-    #   env: TARGET=mips64el-unknown-linux-gnuabi64
-    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-    #        SKIP_TESTS=1
-    # - os: linux
-    #   env: TARGET=s390x-unknown-linux-gnu
-    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-    #        SKIP_TESTS=1
-    #
-    # # Android use a local docker image
-    # - os: linux
-    #   env: TARGET=arm-linux-androideabi
-    #        DOCKER=android
-    #        SKIP_TESTS=1
-    # - os: linux
-    #   env: TARGET=armv7-linux-androideabi
-    #        DOCKER=android
-    #        SKIP_TESTS=1
-    # - os: linux
-    #   env: TARGET=aarch64-linux-android
-    #        DOCKER=android
-    #        SKIP_TESTS=1
-    # - os: linux
-    #   env: TARGET=i686-linux-android
-    #        DOCKER=android
-    #        SKIP_TESTS=1
-    #
-    # # On OSX we want to target 10.7 so we ensure that the appropriate
-    # # environment variable is set to tell the linker what we want.
-    # - os: osx
-    #   env: TARGET=i686-apple-darwin
-    #        MACOSX_DEPLOYMENT_TARGET=10.7
-    # - os: osx
-    #   env: TARGET=x86_64-apple-darwin
-    #        MACOSX_DEPLOYMENT_TARGET=10.7
+    - os: linux
+      env: TARGET=arm-unknown-linux-gnueabi
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=arm-unknown-linux-gnueabihf
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=armv7-unknown-linux-gnueabihf
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=aarch64-unknown-linux-gnu
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=x86_64-unknown-freebsd
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=x86_64-unknown-netbsd
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=powerpc-unknown-linux-gnu
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=powerpc64-unknown-linux-gnu
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=powerpc64le-unknown-linux-gnu
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=mips-unknown-linux-gnu
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=mipsel-unknown-linux-gnu
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=mips64-unknown-linux-gnuabi64
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=mips64el-unknown-linux-gnuabi64
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=s390x-unknown-linux-gnu
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+
+    # Android use a local docker image
+    - os: linux
+      env: TARGET=arm-linux-androideabi
+           DOCKER=android
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=armv7-linux-androideabi
+           DOCKER=android
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=aarch64-linux-android
+           DOCKER=android
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=i686-linux-android
+           DOCKER=android
+           SKIP_TESTS=1
+
+    # On OSX we want to target 10.7 so we ensure that the appropriate
+    # environment variable is set to tell the linker what we want.
+    - os: osx
+      env: TARGET=i686-apple-darwin
+           MACOSX_DEPLOYMENT_TARGET=10.7
+    - os: osx
+      env: TARGET=x86_64-apple-darwin
+           MACOSX_DEPLOYMENT_TARGET=10.7
 
 cache:
   # We're going to download things we don't necessarily want to cache into the `target` directory, so

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,89 +17,89 @@ matrix:
     # Cross builds happen in the `rust-slave-linux-cross` image to ensure that
     # we use the right cross compilers for these targets. That image should
     # bundle all the gcc cross compilers to enable us to build OpenSSL
-    - os: linux
-      env: TARGET=arm-unknown-linux-gnueabi
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-           SKIP_TESTS=1
-    - os: linux
-      env: TARGET=arm-unknown-linux-gnueabihf
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-           SKIP_TESTS=1
-    - os: linux
-      env: TARGET=armv7-unknown-linux-gnueabihf
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-           SKIP_TESTS=1
-    - os: linux
-      env: TARGET=aarch64-unknown-linux-gnu
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-           SKIP_TESTS=1
-    - os: linux
-      env: TARGET=x86_64-unknown-freebsd
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-           SKIP_TESTS=1
-    - os: linux
-      env: TARGET=x86_64-unknown-netbsd
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-           SKIP_TESTS=1
-    - os: linux
-      env: TARGET=powerpc-unknown-linux-gnu
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-           SKIP_TESTS=1
-    - os: linux
-      env: TARGET=powerpc64-unknown-linux-gnu
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-           SKIP_TESTS=1
-    - os: linux
-      env: TARGET=powerpc64le-unknown-linux-gnu
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-           SKIP_TESTS=1
-    - os: linux
-      env: TARGET=mips-unknown-linux-gnu
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-           SKIP_TESTS=1
-    - os: linux
-      env: TARGET=mipsel-unknown-linux-gnu
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-           SKIP_TESTS=1
-    - os: linux
-      env: TARGET=mips64-unknown-linux-gnuabi64
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-           SKIP_TESTS=1
-    - os: linux
-      env: TARGET=mips64el-unknown-linux-gnuabi64
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-           SKIP_TESTS=1
-    - os: linux
-      env: TARGET=s390x-unknown-linux-gnu
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
-           SKIP_TESTS=1
-
-    # Android use a local docker image
-    - os: linux
-      env: TARGET=arm-linux-androideabi
-           DOCKER=android
-           SKIP_TESTS=1
-    - os: linux
-      env: TARGET=armv7-linux-androideabi
-           DOCKER=android
-           SKIP_TESTS=1
-    - os: linux
-      env: TARGET=aarch64-linux-android
-           DOCKER=android
-           SKIP_TESTS=1
-    - os: linux
-      env: TARGET=i686-linux-android
-           DOCKER=android
-           SKIP_TESTS=1
-
-    # On OSX we want to target 10.7 so we ensure that the appropriate
-    # environment variable is set to tell the linker what we want.
-    - os: osx
-      env: TARGET=i686-apple-darwin
-           MACOSX_DEPLOYMENT_TARGET=10.7
-    - os: osx
-      env: TARGET=x86_64-apple-darwin
-           MACOSX_DEPLOYMENT_TARGET=10.7
+    # - os: linux
+    #   env: TARGET=arm-unknown-linux-gnueabi
+    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+    #        SKIP_TESTS=1
+    # - os: linux
+    #   env: TARGET=arm-unknown-linux-gnueabihf
+    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+    #        SKIP_TESTS=1
+    # - os: linux
+    #   env: TARGET=armv7-unknown-linux-gnueabihf
+    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+    #        SKIP_TESTS=1
+    # - os: linux
+    #   env: TARGET=aarch64-unknown-linux-gnu
+    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+    #        SKIP_TESTS=1
+    # - os: linux
+    #   env: TARGET=x86_64-unknown-freebsd
+    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+    #        SKIP_TESTS=1
+    # - os: linux
+    #   env: TARGET=x86_64-unknown-netbsd
+    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+    #        SKIP_TESTS=1
+    # - os: linux
+    #   env: TARGET=powerpc-unknown-linux-gnu
+    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+    #        SKIP_TESTS=1
+    # - os: linux
+    #   env: TARGET=powerpc64-unknown-linux-gnu
+    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+    #        SKIP_TESTS=1
+    # - os: linux
+    #   env: TARGET=powerpc64le-unknown-linux-gnu
+    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+    #        SKIP_TESTS=1
+    # - os: linux
+    #   env: TARGET=mips-unknown-linux-gnu
+    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+    #        SKIP_TESTS=1
+    # - os: linux
+    #   env: TARGET=mipsel-unknown-linux-gnu
+    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+    #        SKIP_TESTS=1
+    # - os: linux
+    #   env: TARGET=mips64-unknown-linux-gnuabi64
+    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+    #        SKIP_TESTS=1
+    # - os: linux
+    #   env: TARGET=mips64el-unknown-linux-gnuabi64
+    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+    #        SKIP_TESTS=1
+    # - os: linux
+    #   env: TARGET=s390x-unknown-linux-gnu
+    #        DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+    #        SKIP_TESTS=1
+    #
+    # # Android use a local docker image
+    # - os: linux
+    #   env: TARGET=arm-linux-androideabi
+    #        DOCKER=android
+    #        SKIP_TESTS=1
+    # - os: linux
+    #   env: TARGET=armv7-linux-androideabi
+    #        DOCKER=android
+    #        SKIP_TESTS=1
+    # - os: linux
+    #   env: TARGET=aarch64-linux-android
+    #        DOCKER=android
+    #        SKIP_TESTS=1
+    # - os: linux
+    #   env: TARGET=i686-linux-android
+    #        DOCKER=android
+    #        SKIP_TESTS=1
+    #
+    # # On OSX we want to target 10.7 so we ensure that the appropriate
+    # # environment variable is set to tell the linker what we want.
+    # - os: osx
+    #   env: TARGET=i686-apple-darwin
+    #        MACOSX_DEPLOYMENT_TARGET=10.7
+    # - os: osx
+    #   env: TARGET=x86_64-apple-darwin
+    #        MACOSX_DEPLOYMENT_TARGET=10.7
 
 cache:
   - cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,7 @@ install:
     sh -s -- --prefix=$HOME/rust --spec=nightly-2016-11-06 --with-target=$TARGET
 
 script:
-  - mkdir target
+  - mkdir -p target
   - if [ ! -z "$DOCKER" ]; then
       sh ci/build-run-docker.sh "$DOCKER" "$TARGET" "$SKIP_TESTS";
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,8 @@ matrix:
     #        MACOSX_DEPLOYMENT_TARGET=10.7
 
 cache:
+  # We're going to download things we don't necessarily want to cache into the `target` directory, so
+  # don't use travis's native `cargo` caching, which just grabs the whole folder.
   - directories:
     - target/$TARGET/openssl/openssl-install
     - target/cargo-home

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,9 +102,10 @@ matrix:
     #        MACOSX_DEPLOYMENT_TARGET=10.7
 
 cache:
-  - cargo
   - directories:
     - target/$TARGET/openssl/openssl-install
+    - target/cargo-home
+    - target/$TARGET/release
 
 branches:
   only:

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -159,8 +159,8 @@ else
   mkdir -p target/$TARGET/openssl
   out=`pwd`/target/$TARGET/openssl/openssl-$OPENSSL_VERS.tar.gz
   curl -o $out https://www.openssl.org/source/openssl-$OPENSSL_VERS.tar.gz
-  echo "$OPENSSL_SHA256 $out" > $out.checksum
-  sha256sum -c $out.checksum
+  sha256sum $out > $out.sha256
+  test $OPENSSL_SHA256 = `cut -d ' ' -f 1 $out.sha256`
 
   tar xf $out -C target/$TARGET/openssl
   (cd target/$TARGET/openssl/openssl-$OPENSSL_VERS && \

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -147,11 +147,13 @@ esac
 
 install=`pwd`/target/$TARGET/openssl/openssl-install
 
-if [ ! -e "$install/lib/libcrypto.a" ]; then
+if (sh -c "$install/bin/openssl version | grep $OPENSSL_VERS > /dev/null" 2> /dev/null); then
+  echo 'Using cached OpenSSL static libs'
+else
   mkdir -p target/$TARGET/openssl
   out=`pwd`/target/$TARGET/openssl/openssl-$OPENSSL_VERS.tar.gz
   curl -o $out https://www.openssl.org/source/openssl-$OPENSSL_VERS.tar.gz
-  echo $OPENSSL_SHA256 $out | sha256sum -c
+  echo "$OPENSSL_SHA256 $out" | sha256sum -c
 
   tar xf $out -C target/$TARGET/openssl
   (cd target/$TARGET/openssl/openssl-$OPENSSL_VERS && \
@@ -160,8 +162,6 @@ if [ ! -e "$install/lib/libcrypto.a" ]; then
    $SETARCH ./Configure --prefix=$install no-dso $OPENSSL_OS $OPENSSL_CFLAGS -fPIC && \
    make -j4 && \
    make install)
-else
-  echo 'Using cached OpenSSL static libs'
 fi
 
 # Variables to the openssl-sys crate to link statically against the OpenSSL we

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -145,7 +145,7 @@ case $TARGET in
     ;;
 esac
 
-install=`pwd`/target/$TARGET/openssl/openssl-install
+install=`pwd`/target/$TARGET/openssl/openssl-install-$OPENSSL_VERS
 
 if (sh -c "$install/bin/openssl version | grep $OPENSSL_VERS > /dev/null" 2> /dev/null); then
   echo 'Using cached OpenSSL static libs'
@@ -172,6 +172,9 @@ else
 
    mv $install $final_install_path
    install=$final_install_path
+
+   # Check everything went okay
+   ls $install
 fi
 
 # Variables to the openssl-sys crate to link statically against the OpenSSL we

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -2,6 +2,9 @@
 
 set -ex
 
+# let's see what we got from the cache
+tree `pwd`/target
+
 # For some unknown reason libz is not found in the android docker image, so we
 # use this workaround
 case $TARGET in

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -145,20 +145,25 @@ case $TARGET in
     ;;
 esac
 
-mkdir -p target/$TARGET/openssl
 install=`pwd`/target/$TARGET/openssl/openssl-install
-out=`pwd`/target/$TARGET/openssl/openssl-$OPENSSL_VERS.tar.gz
-curl -o $out https://www.openssl.org/source/openssl-$OPENSSL_VERS.tar.gz
-sha256sum $out > $out.sha256
-test $OPENSSL_SHA256 = `cut -d ' ' -f 1 $out.sha256`
 
-tar xf $out -C target/$TARGET/openssl
-(cd target/$TARGET/openssl/openssl-$OPENSSL_VERS && \
- CC=$OPENSSL_CC \
- AR=$OPENSSL_AR \
- $SETARCH ./Configure --prefix=$install no-dso $OPENSSL_OS $OPENSSL_CFLAGS -fPIC && \
- make -j4 && \
- make install)
+if [ ! -e "$install"]; then
+  mkdir -p target/$TARGET/openssl
+  out=`pwd`/target/$TARGET/openssl/openssl-$OPENSSL_VERS.tar.gz
+  curl -o $out https://www.openssl.org/source/openssl-$OPENSSL_VERS.tar.gz
+  sha256sum $out > $out.sha256
+  test $OPENSSL_SHA256 = `cut -d ' ' -f 1 $out.sha256`
+
+  tar xf $out -C target/$TARGET/openssl
+  (cd target/$TARGET/openssl/openssl-$OPENSSL_VERS && \
+   CC=$OPENSSL_CC \
+   AR=$OPENSSL_AR \
+   $SETARCH ./Configure --prefix=$install no-dso $OPENSSL_OS $OPENSSL_CFLAGS -fPIC && \
+   make -j4 && \
+   make install)
+else
+  echo 'Using cached OpenSSL static libs'
+fi
 
 # Variables to the openssl-sys crate to link statically against the OpenSSL we
 # just compiled above

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # let's see what we got from the cache
-tree `pwd`/target
+find target -maxdepth 3
 
 # For some unknown reason libz is not found in the android docker image, so we
 # use this workaround

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -147,12 +147,11 @@ esac
 
 install=`pwd`/target/$TARGET/openssl/openssl-install
 
-if [ ! -e "$install" ]; then
+if [ ! -e "$install/lib/libcrypto.a" ]; then
   mkdir -p target/$TARGET/openssl
   out=`pwd`/target/$TARGET/openssl/openssl-$OPENSSL_VERS.tar.gz
   curl -o $out https://www.openssl.org/source/openssl-$OPENSSL_VERS.tar.gz
-  sha256sum $out > $out.sha256
-  test $OPENSSL_SHA256 = `cut -d ' ' -f 1 $out.sha256`
+  echo $OPENSSL_SHA256 $out | sha256sum -c
 
   tar xf $out -C target/$TARGET/openssl
   (cd target/$TARGET/openssl/openssl-$OPENSSL_VERS && \

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -147,7 +147,7 @@ esac
 
 install=`pwd`/target/$TARGET/openssl/openssl-install
 
-if [ ! -e "$install"]; then
+if [ ! -e "$install" ]; then
   mkdir -p target/$TARGET/openssl
   out=`pwd`/target/$TARGET/openssl/openssl-$OPENSSL_VERS.tar.gz
   curl -o $out https://www.openssl.org/source/openssl-$OPENSSL_VERS.tar.gz

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -145,7 +145,7 @@ case $TARGET in
     ;;
 esac
 
-install=`pwd`/target/$TARGET/openssl/openssl-install-$OPENSSL_VERS
+install=`pwd`/target/$TARGET/openssl/openssl-install/$OPENSSL_VERS
 
 if (sh -c "$install/bin/openssl version | grep $OPENSSL_VERS > /dev/null" 2> /dev/null); then
   echo 'Using cached OpenSSL static libs'

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -2,9 +2,6 @@
 
 set -ex
 
-# let's see what we got from the cache
-find target -maxdepth 3
-
 # For some unknown reason libz is not found in the android docker image, so we
 # use this workaround
 case $TARGET in
@@ -147,6 +144,9 @@ case $TARGET in
     exit 1
     ;;
 esac
+
+# let's see what we got from the cache
+find target/$TARGET -maxdepth 4
 
 install=`pwd`/target/$TARGET/openssl/openssl-install/$OPENSSL_VERS
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -7,7 +7,7 @@ echo "toolchain versions\n------------------"
 rustc -vV
 cargo -vV
 
-cargo build --release --target $TARGET
+cargo build -v --release --target $TARGET
 
 if [ -z "$SKIP_TESTS" ]; then
   cargo test --release -p rustup-dist --target $TARGET

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -7,7 +7,7 @@ echo "toolchain versions\n------------------"
 rustc -vV
 cargo -vV
 
-cargo build -v --release --target $TARGET
+cargo build --release --target $TARGET
 
 if [ -z "$SKIP_TESTS" ]; then
   cargo test --release -p rustup-dist --target $TARGET


### PR DESCRIPTION
Activated both `cargo` and arbitrary directory. Strictly,
the definition of the `cargo` cache type just takes the
whole `target` dir from the route, which will happen to
pick up OpenSSL's static libs as well, but since that's
not actually an output of cargo, it seems better to be
explicit. This way we don't have to worry about the case
that travis gets more targetted caching rules.

This is the start of investigating #1027