### PR TITLE
Switch on travis's caching features.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ matrix:
       env: TARGET=s390x-unknown-linux-gnu
            DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
            SKIP_TESTS=1
-    
+
     # Android use a local docker image
     - os: linux
       env: TARGET=arm-linux-androideabi
@@ -91,7 +91,7 @@ matrix:
       env: TARGET=i686-linux-android
            DOCKER=android
            SKIP_TESTS=1
-    
+
     # On OSX we want to target 10.7 so we ensure that the appropriate
     # environment variable is set to tell the linker what we want.
     - os: osx
@@ -107,6 +107,7 @@ cache:
   - directories:
     - target/$TARGET/openssl/openssl-install
     - target/$TARGET/release
+    - target/release/deps
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ matrix:
       env: TARGET=s390x-unknown-linux-gnu
            DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
            SKIP_TESTS=1
-
+    
     # Android use a local docker image
     - os: linux
       env: TARGET=arm-linux-androideabi
@@ -91,7 +91,7 @@ matrix:
       env: TARGET=i686-linux-android
            DOCKER=android
            SKIP_TESTS=1
-
+    
     # On OSX we want to target 10.7 so we ensure that the appropriate
     # environment variable is set to tell the linker what we want.
     - os: osx
@@ -100,6 +100,13 @@ matrix:
     - os: osx
       env: TARGET=x86_64-apple-darwin
            MACOSX_DEPLOYMENT_TARGET=10.7
+
+cache:
+  # We're going to download things we don't necessarily want to cache into the `target` directory, so
+  # don't use travis's native `cargo` caching, which just grabs the whole folder.
+  - directories:
+    - target/$TARGET/openssl/openssl-install
+    - target/$TARGET/release
 
 branches:
   only:
@@ -117,7 +124,7 @@ install:
     sh -s -- --prefix=$HOME/rust --spec=nightly-2016-11-06 --with-target=$TARGET
 
 script:
-  - mkdir target
+  - mkdir -p target/$TARGET
   - if [ ! -z "$DOCKER" ]; then
       sh ci/build-run-docker.sh "$DOCKER" "$TARGET" "$SKIP_TESTS";
     else

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,3 +76,4 @@ test = false # no unit tests
 name = "rustup-init"
 path = "src/rustup-cli/main.rs"
 test = false # no unit tests
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,4 +76,3 @@ test = false # no unit tests
 name = "rustup-init"
 path = "src/rustup-cli/main.rs"
 test = false # no unit tests
-

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -7,7 +7,7 @@ echo "toolchain versions\n------------------"
 rustc -vV
 cargo -vV
 
-cargo build --release --target $TARGET
+cargo build -v --release --target $TARGET
 
 if [ -z "$SKIP_TESTS" ]; then
   cargo test --release -p rustup-dist --target $TARGET


### PR DESCRIPTION
We can re-use the following across builds:
* compiled OpenSSL libs
* compiled crate dependencies

Use specific folder caching because we've got a custom installation
of rust/cargo etc. so travis's `cargo` caching can't really be
expected to get that right. Move the install location of
OpenSSL to ensure that if the version is bumped, we won't get a bad
cache hit and silently fail to apply the upgrade.

If the rust toolchain gets bumped, it would be worth checking what
gains can be got by incremental compilation of the local crate.